### PR TITLE
client improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - classifier
       - graphql
   graphql:
-    image: uscictdocker/opentutor-graphql:2.0.0
+    image: uscictdocker/opentutor-graphql:2.1.0
     ports:
       - 3001:3001
     environment:
@@ -127,5 +127,4 @@ services:
         target: /app/shared
         read_only: true
   tutor:
-    image: uscictdocker/opentutor-web-client:2.0.0
-  
+    image: uscictdocker/opentutor-web-client:2.3.0

--- a/ebs/bundle/Dockerrun.aws.json
+++ b/ebs/bundle/Dockerrun.aws.json
@@ -129,7 +129,7 @@
     },
     {
       "name": "graphql",
-      "image": "uscictdocker/opentutor-graphql:2.0.0",
+      "image": "uscictdocker/opentutor-graphql:2.1.0",
       "essential": true,
       "memory": 1024,
       "mountPoints": [
@@ -244,7 +244,7 @@
     },
     {
       "name": "tutor",
-      "image": "uscictdocker/opentutor-web-client:2.0.0",
+      "image": "uscictdocker/opentutor-web-client:2.3.0",
       "essential": true,
       "memory": 512,
       "mountPoints": [

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -70,7 +70,7 @@ server {
     }
 
     location ~* /tutor {
-        proxy_pass http://tutor:3000;
+        proxy_pass http://tutor;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
This merges [2.2.0](https://github.com/opentutor/opentutor.info-beanstalk-app/releases/tag/2.2.0) changes made to opentutor.info back to the main/public `beanstalk-app` repo

 - tutor client now uses no-auth gql query for lesson data
 - tutor client now runs in compact nginx docker image as fully static
 - tutor-client docker image size reduced to 28MB from 200+MB